### PR TITLE
Add $use_chroot to rsync::server::module

### DIFF
--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -7,6 +7,7 @@
 #   $comment          - rsync comment
 #   $read_only        - yes||no, defaults to yes
 #   $write_only       - yes||no, defaults to no
+#   $use_chroot       - yes|no, defaults to undef
 #   $list             - yes||no, defaults to yes
 #   $uid              - uid of rsync server, defaults to 0
 #   $gid              - gid of rsync server, defaults to 0
@@ -52,6 +53,7 @@ define rsync::server::module (
   $outgoing_chmod                     = '0644',
   $max_connections                    = '0',
   $lock_file                          = '/var/run/rsyncd.lock',
+  $use_chroot                         = undef,
   $secrets_file                       = undef,
   Optional[Array] $exclude            = undef,
   Optional[Array] $auth_users         = undef,
@@ -73,6 +75,7 @@ define rsync::server::module (
       'comment'            => $comment,
       'read_only'          => $read_only,
       'write_only'         => $write_only,
+      'use_chroot'         => $use_chroot,
       'list'               => $list,
       'uid'                => $uid,
       'gid'                => $gid,

--- a/spec/defines/server_module_spec.rb
+++ b/spec/defines/server_module_spec.rb
@@ -49,6 +49,7 @@ describe 'rsync::server::module', :type => :define do
     it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^refuse options\s*=.*$/) }
     it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^pre-xfer exec\s*=.*$/) }
     it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^post-xfer exec\s*=.*$/) }
+    it { is_expected.not_to contain_concat__fragment(fragment_name).with_content(/^use chroot\s*=.*$/) }
   end
 
   describe "when overriding max connections" do
@@ -120,5 +121,12 @@ describe 'rsync::server::module', :type => :define do
       mandatory_params.merge({ :log_file => '/var/log/rsync.log' })
     end
     it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^log file\s*=\s*\/var\/log\/rsync.log$/)}
+  end
+
+  describe "when overriding use_chroot" do
+    let :params do
+      mandatory_params.merge({ :use_chroot => 'yes' })
+    end
+    it { is_expected.to contain_concat__fragment(fragment_name).with_content(/^use chroot\s*=\s*yes$/)}
   end
 end

--- a/templates/module.epp
+++ b/templates/module.epp
@@ -8,6 +8,9 @@ write only         = <%= $write_only %>
 list               = <%= $list %>
 uid                = <%= $uid %>
 gid                = <%= $gid %>
+<% if $use_chroot { -%>
+use chroot         = <%= $use_chroot %>
+<% } -%>
 <% if $incoming_chmod { -%>
 incoming chmod     = <%= $incoming_chmod %>
 <% } -%>


### PR DESCRIPTION
This allow a specific module to override the global server parameter.